### PR TITLE
Total dick removal

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -98,7 +98,6 @@ def main(argv):
     (LOWER(payload_commit_msg) CONTAINS "shit") OR
     (LOWER(payload_commit_msg) CONTAINS " tits") OR
     (LOWER(payload_commit_msg) CONTAINS "asshole") OR
-    (LOWER(payload_commit_msg) CONTAINS "dick") OR
     (LOWER(payload_commit_msg) CONTAINS "cocksucker") OR
     (LOWER(payload_commit_msg) CONTAINS "cunt") OR
     (LOWER(payload_commit_msg) CONTAINS " hell ") OR


### PR DESCRIPTION
I recommend removing 'dick' from your list of terms that you look for in the commit logs, because it's unfair to all the Dicks in the world (that is, people with the given name of 'Dick' or whose surname contains 'Dick').
