### PR TITLE
Reduce shit queries by 50%

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -112,7 +112,6 @@ def main(argv):
     (LOWER(payload_commit_msg) CONTAINS "faggot") OR
     (LOWER(payload_commit_msg) CONTAINS "nigger") OR
     (LOWER(payload_commit_msg) CONTAINS "sperm") OR
-    (LOWER(payload_commit_msg) CONTAINS "shit") OR
     (LOWER(payload_commit_msg) CONTAINS "dildo") OR
     (LOWER(payload_commit_msg) CONTAINS "wanker") OR
     (LOWER(payload_commit_msg) CONTAINS "prick") OR


### PR DESCRIPTION
Nothing against "shit" or anything. It's every bit as good as "douche" et al. But I'm pretty sure it only needs to be mentioned in the query once, not twice.