### PR TITLE
catching all 7 dirty words

### DIFF
--- a/word_list.py
+++ b/word_list.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-word_list = [" fuck ", " bitch ", " shit ", " tits ", " asshole ", " arsehole ", " cocksucker", " cunt", " hell ", " douche", " testicle", " twat", " bastard", " sperm", " shit", " dildo", " wanker", " prick", " penis", " vagina", " whore", " boner"]
+word_list = [" fuck ", " bitch ", " shit ", " tits ", " asshole ", " arsehole ", " cocksucker", " cunt", " hell ", " douche", " testicle", " twat", " bastard", " sperm", " shit", " dildo", " wanker", " prick", " penis", " vagina", " whore", " boner", " piss", " motherfuck"]


### PR DESCRIPTION
Modified word_list.py to catch all of George Carlin's 7 dirty words you can't say on television
- the words being shit, piss, fuck, cunt, cocksucker, motherfucker and tits.